### PR TITLE
ZMK v0.3.0 にアップグレード

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   build:
-    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@v0.2.1
+    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@v0.3.0
 
   release:
     if: startsWith(github.ref, 'refs/tags/')  # タグpush時のみ

--- a/config/west.yml
+++ b/config/west.yml
@@ -9,14 +9,14 @@ manifest:
   projects:
     - name: zmk
       remote: zmkfirmware
-      revision: v0.2.1
+      revision: v0.3.0
       import: app/west.yml
     - name: zmk-pmw3610-driver
       remote: badjeff
       revision: zmk-0.3
     - name: prospector-zmk-module
       remote: prospector
-      revision: v1.1.0
+      revision: v2.2b
       path: modules/prospector-zmk-module
   self:
     path: config


### PR DESCRIPTION
## Summary
- ZMK 本体を v0.2.1 → v0.3.0 に更新
- prospector-zmk-module を v1.1.0 → v2.2b に更新（v2.1.0 は MIPI_DBI Kconfig の型定義不足で v0.3 非互換のため）
- GitHub Actions の reusable workflow を v0.3.0 に更新
- zmk-pmw3610-driver は既に `zmk-0.3` ブランチを参照しているため変更なし

## Test plan
- [x] ローカル devcontainer で seeeduino_xiao_ble + suzuri シールドのビルド成功を確認済み
- [x] GitHub Actions でのビルド成功を確認